### PR TITLE
ensure that a slot isn't inserted accidentally during exit_task

### DIFF
--- a/manager/src/lib.rs
+++ b/manager/src/lib.rs
@@ -488,10 +488,12 @@ impl CronManager {
         // Get previous task hashes in slot, find index of task hash, remove
         let next_slot = self.get_slot_from_cadence(task.cadence.clone());
         let mut slot_tasks = self.slots.get(&next_slot).unwrap_or(Vec::new());
-        if let Some(index) = slot_tasks.iter().position(|h| *h == task_hash) {
-            slot_tasks.remove(index);
+        if slot_tasks.len() != 0 {
+            if let Some(index) = slot_tasks.iter().position(|h| *h == task_hash) {
+                slot_tasks.remove(index);
+            }
+            self.slots.insert(&next_slot, &slot_tasks);
         }
-        self.slots.insert(&next_slot, &slot_tasks);
     }
 
     /// Executes a task based on the current task slot


### PR DESCRIPTION
My small contribution for the day is tracking down this use case.
I set up a recurring task that adds deposit to a function call that can't take deposit. When `proxy_call`'ed, it fails, then runs `exit_task`, which tries to get a slot and remove the tasks I believe. During this process it grabbed a non-existent slot, tried to remove stuff, and then inserted it back into state. That insertion, however, just inserts a blank slot with no tasks. This has the potential to bloat state.

So it's hidden behind a simple if statement now.